### PR TITLE
Add GitHub Actions workflows for Docker image builds

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -1,0 +1,92 @@
+name: docker-build
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag (e.g., v1.0.0, dev)"
+        required: true
+        default: dev
+      publish:
+        description: "Push to GHCR?"
+        required: true
+        default: "false"
+        type: choice
+        options: ["false","true"]
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+      publish:
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions: { contents: read, packages: write }
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build and load tar1090-node
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.tar1090
+          platforms: linux/arm64
+          push: false
+          load: true
+          tags: tar1090-node:${{ inputs.tag }}
+          cache-from: type=gha,scope=tar1090-node
+          cache-to: type=gha,mode=max,scope=tar1090-node
+          labels: |
+            org.opencontainers.image.source=${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Export image to tarball
+        run: |
+          docker save tar1090-node:${{ inputs.tag }} -o /tmp/tar1090-node.tar
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tar1090-node-image
+          path: /tmp/tar1090-node.tar
+          retention-days: 1
+
+  publish:
+    needs: build
+    if: ${{ inputs.publish == 'true' }}
+    runs-on: ubuntu-latest
+    permissions: { contents: read, packages: write }
+
+    steps:
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download image
+        uses: actions/download-artifact@v4
+        with:
+          name: tar1090-node-image
+          path: /tmp
+
+      - name: Load and push tar1090-node
+        run: |
+          docker load -i /tmp/tar1090-node.tar
+          docker tag tar1090-node:${{ inputs.tag }} ghcr.io/offworldlabs/tar1090-node:${{ inputs.tag }}
+          docker push ghcr.io/offworldlabs/tar1090-node:${{ inputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'  # Automatic on tags e.g. v0.1.0, v1.0.0
+  workflow_dispatch:  # Manual trigger
+    inputs:
+      version:
+        description: "Release version (e.g., v1.0.0, dev)"
+        required: true
+
+jobs:
+  build-and-publish:
+    name: Build and publish Docker image
+    uses: ./.github/workflows/docker_build.yml
+    with:
+      tag: ${{ github.event_name == 'push' && github.ref_name || inputs.version }}
+      publish: "true"
+
+  create-release:
+    name: Create GitHub Release
+    needs: build-and-publish
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions: { contents: write }
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          body: |
+            ## Docker Image Published
+
+            The tar1090-node image has been built and published to GitHub Container Registry:
+
+            - `ghcr.io/offworldlabs/tar1090-node:${{ github.ref_name }}`
+
+            Pull the image with:
+            ```bash
+            docker pull ghcr.io/offworldlabs/tar1090-node:${{ github.ref_name }}
+            ```
+
+            ## Deployment
+
+            To use this image in your deployment, update your docker-compose.yml:
+            ```yaml
+            tar1090:
+              image: ghcr.io/offworldlabs/tar1090-node:${{ github.ref_name }}
+              restart: always
+              network_mode: host
+              # ... rest of configuration
+            ```


### PR DESCRIPTION
Adds automated Docker image building and publishing to GHCR.

## Changes
- Add \`docker_build.yml\`: Reusable workflow for building ARM64 images
- Add \`release.yml\`: Automated releases on version tags (\`v*.*.*\`)
- Images published to \`ghcr.io/offworldlabs/tar1090-node\`
- Follows blah2 workflow pattern

## Testing
After merge, can trigger manually via Actions tab or push a version tag.
